### PR TITLE
Add gstreamer dependency to enable H.264 playback on Firefox.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+debathena-extra-software (1.10) unstable; urgency=low
+
+  * Add gstreamer1.0-libav (gstreamer0.10-ffmpeg for precise) to the
+    dependencies. This allows H.264 HTML5 playback in recent versions of
+    Firefox. (Trac: #1566)
+  * Add gstreamer1.0-vaapi (gstreamer0.10-vaapi for precise) to recommends
+    for optional hardware accelearted H.264 playback. Additional VAAPI drivers
+    may be needed.
+
+ -- Lizhou Sha <slz@mit.edu>  Thu, 13 Aug 2015 22:23:20 -0400
+
 debathena-extra-software (1.9) unstable; urgency=medium
 
   * Remove chromium-config from the dependencies.  It has different name on

--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Depends: debathena-extra-software-nox,
   xmonad, suckless-tools | dwm-tools, xmobar,
   git-gui, gitk,
   icedtea-7-plugin | icedtea6-plugin,
+  gstreamer1.0-libav | gstreamer0.10-ffmpeg,
   ${misc:Depends}
 Recommends: flashplugin-installer | flashplugin-nonfree,
   mplayer,
@@ -35,7 +36,8 @@ Recommends: flashplugin-installer | flashplugin-nonfree,
   ttf-xfree86-nonfree,
   poppler-data,
   motif-clients,
-  wmbubble, wmfire
+  wmbubble, wmfire,
+  gstreamer1.0-vaapi | gstreamer0.10-vaapi
 Description: Athena auxiliary software
  This package pulls in miscellaneous non-Athena-specific software
  for a fully-stocked Athena workstation.


### PR DESCRIPTION
(Trac #1566)

Signed-off-by: Lizhou Sha slz@mit.edu
